### PR TITLE
Bug reproduction

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,3 +5,4 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'graphql', '1.10.10'
+gem 'pry'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -42,7 +42,7 @@ GEM
     debase-ruby_core_source (0.10.9)
     diff-lcs (1.3)
     erubi (1.9.0)
-    google-protobuf (3.13.0-x86_64-linux)
+    google-protobuf (3.13.0)
     graphql (1.10.10)
     i18n (1.8.5)
       concurrent-ruby (~> 1.0)
@@ -115,6 +115,7 @@ DEPENDENCIES
   appraisal
   debase
   graphql (= 1.10.10)
+  pry
   pry-byebug
   rack
   rake

--- a/example/gateway.js
+++ b/example/gateway.js
@@ -3,18 +3,20 @@ const { ApolloGateway } = require('@apollo/gateway');
 
 const gateway = new ApolloGateway({
   serviceList: [
-    { name: 'accounts', url: 'http://localhost:5001/graphql' },
-    { name: 'reviews', url: 'http://localhost:5002/graphql' },
+    // { name: 'accounts', url: 'http://localhost:5001/graphql' },
+    // { name: 'reviews', url: 'http://localhost:5002/graphql' },
     { name: 'products', url: 'http://localhost:5003/graphql' },
-    { name: 'inventory', url: 'http://localhost:5004/graphql' },
+    // { name: 'inventory', url: 'http://localhost:5004/graphql' },
   ],
   debug: true,
 });
 
-(async () => {
+func = (async () => {
   const server = new ApolloServer({ gateway, subscriptions: false });
 
   server.listen({ port: 5000 }).then(({ url }) => {
     console.log(`🚀 Server ready at ${url}`);
   });
-})();
+})
+setTimeout(func, 1500)
+

--- a/example/products.rb
+++ b/example/products.rb
@@ -48,7 +48,7 @@ class Product < BaseObject
 end
 
 class Query < BaseObject
-  field :top_products, [Product], null: false do
+  field :top_products, [Product], null: true do
     argument :first, Int, required: false, default_value: 5
   end
 

--- a/example/supergraph.yml
+++ b/example/supergraph.yml
@@ -1,0 +1,9 @@
+subgraphs:
+#  accounts:
+#    routing_url: http://localhost:5001/graphql
+#  review:
+#    routing_url: http://localhost:5002/graphql
+  products:
+    routing_url: http://localhost:5003/graphql
+#  inventory:
+#    routing_url: http://localhost:5004/graphql


### PR DESCRIPTION
### Summary

Expectation: When we pass an invalid variable (null) as an argument (Boolean), i expect the clients to recognize the error and not pass the query to the server and the server to recognize the invalid value and not execute the query.

What is happening: When we pass a `null` value to a variable that should be `Boolean` and is use in an `@include` directive the gateway will pass the query to the subgraph, (ruby in this case).  GraphQL Ruby treats includes as falsy/truthy and then returns the value properly, finally when the Gateway reruns the query result through the schema, the error in the type (null to Boolean) causes the next highest parent that is nullable to be null

#### ExpressJS Hints

The core GraphQL JS Library doesn't work as i would expect here after reading the documentation

In the docs we advertise a nullable boolean
```
@include(if: Boolean) Only include this field in the result if the argument is true.
@skip(if: Boolean) Skip this field if the argument is true.
```

But the implementation of the system is such that we ignore that the the `if` [value can be null from the documentation.]
(https://github.com/graphql/graphql-js/blob/main/src/execution/collectFields.ts#L179-L181)

And the collection of those values does enforce nullability.
![image](https://user-images.githubusercontent.com/1709860/145486240-a8d159dd-87c2-443e-8fa1-e17ff85f0ed1.png)

The internal Directive specifies that it is a [type of NonNull]
(https://github.com/graphql/graphql-js/blob/82ff6539a5b961b00367ed7d6ac57a7297af2a9a/src/type/directives.ts#L142)


### Setup

All commands ran at root of project

#### Setup Node
 - install node
 - npm install -g yarn
 - yarn install

#### Setup Ruby 
 - Install Ruby (my example i am running  2.7.2p137, don't think it will matter much if stay below 3)
 - gem install bundler
 - bundle install 
 
#### Run Servers
 - Start subgraph `bundle exec ruby ./example/products.rb`
 - Start gateway `yarn run start-gateway`


### Reproduction

This is the query to send in all requests, only variables change

```graphql
query something($includeThing: Boolean = true) {
  topProducts {
    upc
    name @include(if: $includeThing)
  }
}
```

#### Null includeThing argument nulls out the highest top level nullable field

```
// Variables
{ "includeThing": null }

// Result
{
  "data": {
    "topProducts": null
  }
}
```

#### false only removes the name from the result

```
// Variables
{ "includeThing": false }

// Result
{
  "data": {
    "topProducts": [
      {
        "upc": "1"
      },
      {
        "upc": "2"
      },
      {
        "upc": "3"
      }
    ]
  }
}
```

#### true only removes nothing

```
// Variables
{ "includeThing": true }

// Result
{
  "data": {
    "topProducts": [
      {
        "upc": "1",
        "name": "Table"
      },
      {
        "upc": "2",
        "name": "Couch"
      },
      {
        "upc": "3",
        "name": "Chair"
      }
    ]
  }
}
```

#### Invalid errors cause an error

```
// Variables
{ "includeThing": "something" }

// Result
{
  "error": {
    "errors": [
      {
        "message": "Variable \"$includeThing\" got invalid value \"something\"; Expected type Boolean. Boolean cannot represent a non boolean value: \"something\"",
        "locations": [
          {
            "line": 1,
            "column": 17
          }
        ],
        "extensions": {
          "code": "INTERNAL_SERVER_ERROR",
          "exception": {
```


